### PR TITLE
perf: limit sidekiq threads to avoid OOM

### DIFF
--- a/app/controllers/api/v1/bookings_controller.rb
+++ b/app/controllers/api/v1/bookings_controller.rb
@@ -5,9 +5,10 @@ module Api
       # are successfully imported and other lines failed to be imported
       MULTI_STATUS = 207
 
-      # In order to prevent swapping on sidekiq, we enforce a maximum file size
-      # With 100MB as max file size and 5 sidekiq threads, the server will take at most 500MB RAM
-      MAX_FILE_SIZE_MB = 100
+      # In order to prevent swapping on sidekiq, I set a maximum file size
+      # With 100MB as max file size and 2 sidekiq threads, the server will take at most 200MB RAM
+      # If I deploy with my Heroku account with 512GB max memory, I leave 300MB for the system
+      MAX_FILE_SIZE_MB = 100 # Allows about 100,000 lines. Around the Stade de France stadium capacity
 
       def index
         bookings = Booking.all

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 5
+:concurrency: 2
 :queues:
   - default
   - mailers


### PR DESCRIPTION
Default concurrency was 5. But if I consider my Heroku max RAM (512GB), if we consider that every thread treats a 100MB file, it can take 500GB RAM (way too much for my server). Therefore I limit the threads to 2.